### PR TITLE
Adding highlighting for comments in vim syntax

### DIFF
--- a/book/ch01-01-syntax-highlighting.md
+++ b/book/ch01-01-syntax-highlighting.md
@@ -62,9 +62,15 @@ endif
 syn keyword keywords assert case def else enum if in index lat
 syn keyword keywords let match namespace print rel val with
 
+syn region LineComment  start="//" end="$"
+syn region BlockComment start="/\*" end="\*/" contains=LineComment,BlockComment
+
 let b:current_syntax = "flix"
 
 hi def link keywords Statement
+
+hi def link LineComment  Comment
+hi def link BlockComment Comment
 ```
 
 Ensure that your `~/.vimrc` file contains at least the following:

--- a/book/ch01-01-syntax-highlighting.md
+++ b/book/ch01-01-syntax-highlighting.md
@@ -63,7 +63,7 @@ syn keyword keywords assert case def else enum if in index lat
 syn keyword keywords let match namespace print rel val with
 
 syn region LineComment  start="//" end="$"
-syn region BlockComment start="/\*" end="\*/" contains=LineComment,BlockComment
+syn region BlockComment start="/\*" end="\*/"
 
 let b:current_syntax = "flix"
 


### PR DESCRIPTION
This pull request aims to improve flix color syntax highlighting in vim.